### PR TITLE
Fix querying AWS instance types

### DIFF
--- a/scraping/parser.py
+++ b/scraping/parser.py
@@ -276,7 +276,7 @@ def query_instance_types() -> pd.DataFrame:
 
     # AWS parse
     aws_url = "https://databricks.com/product/aws-pricing/instance-types"
-    aws = pd.read_html(aws_url)[0].drop(columns=[6])
+    aws = pd.read_html(aws_url)[0].drop(columns=[0])
     aws.columns = ['type', 'cpu', 'mem', 'light', 'job', 'analysis']
     aws['type'] = aws.type.str.extract(regex)
 


### PR DESCRIPTION
`query_instance_types` reads the AWS instance types from
https://databricks.com/product/aws-pricing/instance-types along with
cpu, memory size and associated DBU. The column with index 6
was dropped in the past, but the page was updated to contain the id
of the instance type in column with index 0.

Example page source:

```html
<table id='tableData'>
  <tbody>
    <tr id=1>
      <td id='id1' value='1'>1</td>
      <td id='name1'>m4.large</td>
      <td id='cpus1'>2</td>
      <td id='gb1'>8</td>
      <td id='dbu1_1' value='0.4' class='dbu1 7'>0.4</td>
      <td id='dbu2_1' value='0.4' class='dbu2 15'>0.4</td>
      <td id='dbu3_1' value='0.4' class='dbu3 40'>0.4</td>
    </tr>
    ...
  </tbody>
</table>
```